### PR TITLE
Add TracingClient class and skip tag when tag_body is false

### DIFF
--- a/lib/elasticsearch/tracer.rb
+++ b/lib/elasticsearch/tracer.rb
@@ -7,8 +7,6 @@ require "elasticsearch/tracer/tracing_client"
 module Elasticsearch
   module Tracer
     class << self
-      attr_accessor :tag_body
-
       def instrument(tracer: OpenTracing.global_tracer, active_span: nil, transport:)
         Elasticsearch::Tracer::Transport.new(tracer: tracer, active_span: active_span, transport: transport)
       end

--- a/lib/elasticsearch/tracer.rb
+++ b/lib/elasticsearch/tracer.rb
@@ -2,10 +2,13 @@ require 'elasticsearch'
 
 require "elasticsearch/tracer/version"
 require "elasticsearch/tracer/transport"
+require "elasticsearch/tracer/tracing_client"
 
 module Elasticsearch
   module Tracer
     class << self
+      attr_accessor :tag_body
+
       def instrument(tracer: OpenTracing.global_tracer, active_span: nil, transport:)
         Elasticsearch::Tracer::Transport.new(tracer: tracer, active_span: active_span, transport: transport)
       end

--- a/lib/elasticsearch/tracer/tracing_client.rb
+++ b/lib/elasticsearch/tracer/tracing_client.rb
@@ -15,10 +15,10 @@ module Elasticsearch
 
       def index(arguments = {})
         # trace this request without tagging the request body
-        Thread.current[:skip_body] = true
+        Thread.current[@transport.object_id.to_s] = true
         super
       ensure
-        Thread.current[:skip_body] = nil
+        Thread.current[@transport.object_id.to_s] = nil
       end
     end
   end

--- a/lib/elasticsearch/tracer/tracing_client.rb
+++ b/lib/elasticsearch/tracer/tracing_client.rb
@@ -15,10 +15,10 @@ module Elasticsearch
 
       def index(arguments = {})
         # trace this request without tagging the request body
-        @transport.tag_body = false
+        Thread.current[:skip_body] = true
         super
       ensure
-        @transport.tag_body = true
+        Thread.current[:skip_body] = nil
       end
     end
   end

--- a/lib/elasticsearch/tracer/tracing_client.rb
+++ b/lib/elasticsearch/tracer/tracing_client.rb
@@ -1,0 +1,25 @@
+require 'elasticsearch/api'
+
+# TracingClient is an extension of the default Elasticsearch client.
+# It overrides the index method to let us avoid tagging the request body in
+# case of very large index/create requsts.
+#
+# Other than that, it behaves the same as the default client and passes calls
+# on to the parent.
+#
+# TracingClient is only meant to be used when also using
+# Elasticsearch::Tracer::Transport, as it expects a tag_body member
+module Elasticsearch
+  module Tracer
+    class TracingClient < ::Elasticsearch::Transport::Client
+
+      def index(arguments = {})
+        # trace this request without tagging the request body
+        @transport.tag_body = false
+        super
+      ensure
+        @transport.tag_body = true
+      end
+    end
+  end
+end

--- a/lib/elasticsearch/tracer/transport.rb
+++ b/lib/elasticsearch/tracer/transport.rb
@@ -3,24 +3,30 @@ module Elasticsearch
     class Transport
       attr_reader :tracer, :active_span, :wrapped
 
+      attr_accessor :tag_body
+
       def initialize(tracer: OpenTracing.global_tracer, active_span: nil, transport:)
         @tracer = tracer
         @active_span = active_span
         @wrapped = transport
+        @tag_body = true
       end
 
       def perform_request(method, path, params={}, body=nil, headers=nil)
+        tags = {
+          'component' => 'elasticsearch-ruby',
+          'span.kind' => 'client',
+          'http.method' => method,
+          'http.url' => path,
+          'db.type' => 'elasticsearch',
+          'elasticsearch.params' => URI.encode_www_form(params)
+        }
+
+        tags['db.statement'] = MultiJson.dump(body) if @tag_body
+
         span = tracer.start_span(method,
                                  child_of: active_span.respond_to?(:call) ? active_span.call : active_span,
-                                 tags: {
-                                  'component' => 'elasticsearch-ruby',
-                                  'span.kind' => 'client',
-                                  'http.method' => method,
-                                  'http.url' => path,
-                                  'db.type' => 'elasticsearch',
-                                  'db.statement' => MultiJson.dump(body),
-                                  'elasticsearch.params' => URI.encode_www_form(params)
-                                 })
+                                 tags: tags)
 
         response = @wrapped.perform_request(method, path, params, body, headers)
         span.set_tag('http.status_code', response.status)

--- a/lib/elasticsearch/tracer/transport.rb
+++ b/lib/elasticsearch/tracer/transport.rb
@@ -19,7 +19,7 @@ module Elasticsearch
           'elasticsearch.params' => URI.encode_www_form(params)
         }
 
-        tags['db.statement'] = MultiJson.dump(body) unless Thread.current[:skip_body]
+        tags['db.statement'] = MultiJson.dump(body) unless Thread.current[self.object_id.to_s]
 
         span = tracer.start_span(method,
                                  child_of: active_span.respond_to?(:call) ? active_span.call : active_span,


### PR DESCRIPTION
Transports are not aware of what call is being made. The `index` call can only be intercepted at the client level.

The simple TracingClient just sets `tag_body` in the tracing transport before calling the default parent `index` method, and unsets it afterwards.